### PR TITLE
feat: hashsets

### DIFF
--- a/aoc/src/commands/day4a.rs
+++ b/aoc/src/commands/day4a.rs
@@ -1,4 +1,9 @@
-use std::{collections::VecDeque, ops::Range, path::PathBuf, str::FromStr};
+use std::{
+    collections::{HashSet, VecDeque},
+    ops::Range,
+    path::PathBuf,
+    str::FromStr,
+};
 
 use clap::Parser;
 
@@ -42,13 +47,14 @@ impl CardScore {
 #[derive(Debug)]
 pub struct Card {
     id: usize,
-    winning_numbers: Vec<usize>,
-    numbers: Vec<usize>,
+    winning_numbers: HashSet<usize>,
+    numbers: HashSet<usize>,
 }
 
 impl Card {
     pub fn count_winning_numbers(&self) -> usize {
-        self.winning_numbers.iter().filter(|w| self.numbers.contains(w)).count()
+        // self.winning_numbers.iter().filter(|w| self.numbers.contains(w)).count()
+        self.winning_numbers.intersection(&self.numbers).count()
     }
 
     pub fn score_part_a(&self) -> usize {
@@ -94,15 +100,15 @@ impl FromStr for Card {
             .parse::<usize>()
             .map_err(|_e| ParseError::new(format!("Failed to read game id: `{}`", s)))?;
 
-        let mut winning_numbers = vec![];
+        let mut winning_numbers = HashSet::new();
         for t in tokens.by_ref().take_while(|t| *t != "|") {
-            winning_numbers.push(t.parse::<usize>().map_err(|_e| {
+            winning_numbers.insert(t.parse::<usize>().map_err(|_e| {
                 ParseError::new(format!("Failed to read winning number: `{}`", s))
             })?);
         }
-        let mut numbers = vec![];
+        let mut numbers = HashSet::new();
         for t in tokens {
-            numbers.push(t.parse::<usize>().map_err(|_e| {
+            numbers.insert(t.parse::<usize>().map_err(|_e| {
                 ParseError::new(format!("Failed to read winning number: `{}`", s))
             })?);
         }


### PR DESCRIPTION
Use hashsets instead of vecs for holding values.

Benchmark on 10x input:
```
❯ hyperfine --warmup 5 './target/release/aoc day4a --input ~/Downloads/day4_big.txt'
Benchmark 1: ./target/release/aoc day4a --input ~/Downloads/day4_big.txt
  Time (mean ± σ):      19.0 ms ±   0.4 ms    [User: 17.8 ms, System: 0.7 ms]
  Range (min … max):    18.0 ms …  20.9 ms    138 runs
  ```